### PR TITLE
Update WhatIP runtime to 46

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,66 @@
+From 4a88ba3739f8516d269fb384eba839973b964f37 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sun, 9 Jun 2024 01:18:31 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ data/org.gabmus.whatip.appdata.xml.in | 33 ++-------------------------------
+ 1 file changed, 2 insertions(+), 31 deletions(-)
+
+diff --git a/data/org.gabmus.whatip.appdata.xml.in b/data/org.gabmus.whatip.appdata.xml.in
+index 9cce654..cf86672 100644
+--- a/data/org.gabmus.whatip.appdata.xml.in
++++ b/data/org.gabmus.whatip.appdata.xml.in
+@@ -31,8 +31,8 @@
+     </screenshots>
+     <url type="homepage">https://whatip.gabmus.org</url>
+     <url type="bugtracker">https://gitlab.gnome.org/gabmus/whatip/-/issues</url>
++    <url type="vcs-browser">https://gitlab.gnome.org/gabmus/whatip</url>
+     <url type="translate">https://gitlab.gnome.org/gabmus/whatip/-/tree/master/po</url>
+-    <url type="donation">https://liberapay.com/gabmus/donate</url>
+     <update_contact>gabmus@disroot.org</update_contact>
+     <releases>
+         <release version="1.2" timestamp="1679766655">
+@@ -105,37 +105,8 @@
+             </description>
+         </release>
+     </releases>
+-    <content_rating type="oars-1.1">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="violence-desecration">none</content_attribute>
+-    <content_attribute id="violence-slavery">none</content_attribute>
+-    <content_attribute id="violence-worship">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="sex-homosexuality">none</content_attribute>
+-    <content_attribute id="sex-prostitution">none</content_attribute>
+-    <content_attribute id="sex-adultery">none</content_attribute>
+-    <content_attribute id="sex-appearance">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">none</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+-  </content_rating>
++    <content_rating type="oars-1.1" />
+   <custom>
+-    <value key="Purism::form_factor">workstation</value>
+     <value key="Purism::form_factor">mobile</value>
+   </custom>
+ 
+--
+libgit2 1.7.2
+

--- a/org.gabmus.whatip.json
+++ b/org.gabmus.whatip.json
@@ -32,11 +32,11 @@
         },
         {
             "name": "iproute2",
-            "buildsystem": "simple",
-            "build-commands": [
-                "./configure",
-                "make",
-                "make PREFIX=\"/app\" DESTDIR=\"/app\" SBINDIR=\"/bin\" install"
+            "buildsystem": "autotools",
+            "make-install-args": [
+                "PREFIX=${FLATPAK_DEST}",
+                "SBINDIR=${FLATPAK_DEST}/bin",
+                "CONFDIR=${FLATPAK_DEST}/etc/iproute2"
             ],
             "sources": [
                 {

--- a/org.gabmus.whatip.json
+++ b/org.gabmus.whatip.json
@@ -141,6 +141,10 @@
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GabMus/whatip",
                     "tag": "1.2"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix_appdata.patch"
                 }
             ]
         }

--- a/org.gabmus.whatip.json
+++ b/org.gabmus.whatip.json
@@ -2,7 +2,7 @@
     "app-id": "org.gabmus.whatip",
     "command": "whatip",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "finish-args": [
         "--device=dri",

--- a/org.gabmus.whatip.json
+++ b/org.gabmus.whatip.json
@@ -12,7 +12,13 @@
         "--socket=fallback-x11"
     ],
     "cleanup": [
-        "/usr"
+        "/include",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "/usr",
+        "*.la",
+        "*.a"
     ],
     "modules": [
         "python-deps.json",


### PR DESCRIPTION
- Update WhatIP runtime to 46 since runtime version 44 has reached end-of-life.
- Fix iproute2 install. Do not install in the `/app/app` folder
- Remove some redundant files to reduce the package size.