### PR TITLE
Update runtime to GNOME 48

### DIFF
--- a/org.gabmus.whatip.json
+++ b/org.gabmus.whatip.json
@@ -2,7 +2,7 @@
     "app-id": "org.gabmus.whatip",
     "command": "whatip",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "finish-args": [
         "--device=dri",
@@ -32,7 +32,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.6.0"
+                    "tag": "v0.16.0"
                 }
             ]
         },


### PR DESCRIPTION
GNOME 48 runtime/sdk brings LibAdw 1.7, with a new dark theme and rounder corner radius. Successful builds require an update of blueprint-compiler to 0.16.0.